### PR TITLE
fix: 修复客户端无法区分消息类型的bug

### DIFF
--- a/cmd/main/room.go
+++ b/cmd/main/room.go
@@ -613,8 +613,10 @@ func (r *Room) handleDouyinEvent(eventData *new_douyin.Webcast_Im_Message, liveN
 	}
 
 	livenameJSON := r.getLiveNamePayload(liveName)
-	finalJSON := make([]byte, 0, len(jsonBytes)+len(livenameJSON))
+	methodJSON := []byte(fmt.Sprintf(`,"method":%s`, strconv.Quote(eventData.Method)))
+	finalJSON := make([]byte, 0, len(jsonBytes)+len(methodJSON)+len(livenameJSON))
 	finalJSON = append(finalJSON, jsonBytes[:lastCloseBrace]...)
+	finalJSON = append(finalJSON, methodJSON...)
 	finalJSON = append(finalJSON, livenameJSON...)
 	finalJSON = append(finalJSON, '}')
 


### PR DESCRIPTION
问题：服务端发送的 JSON 消息未包含 method字段，客户端无法识别消息类型。
修复：在服务端发送 JSON 消息时始终包含 method字段。
影响：客户端现在能正确解析和处理不同类型的消息。