### PR TITLE
feat: support per-room Douyin cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ monitor:
   notify_interval: "30s"
 cookie:
   douyin: ""
+  rooms:
+    # "516466932480": "ttwid=...; sessionid=..."
 ```
 
 项目里也自带了一个示例文件：
@@ -375,13 +377,44 @@ monitor:
 ```
 
 #### `cookie.douyin`
-抖音 Cookie，可选。
+抖音默认 Cookie，可选。
 
-默认不填。
+默认不填。旧版本只配置 `cookie.douyin` 的写法仍然兼容，不需要修改配置文件。
 
 ```yaml
 cookie:
   douyin: "ttwid=...; sessionid=..."
+```
+
+#### `cookie.rooms`
+按直播间 ID 配置 Cookie，可选。
+
+当某些直播间需要使用不同账号登录态时，可以为指定直播间单独配置 Cookie。没有配置直播间 Cookie 的房间会自动回退使用 `cookie.douyin`；如果 `cookie.douyin` 也为空，则继续使用自动获取 Cookie 的逻辑。
+
+```yaml
+cookie:
+  douyin: "默认 Cookie"
+  rooms:
+    "516466932480": "直播间 516466932480 专用 Cookie"
+    "123456789": "直播间 123456789 专用 Cookie"
+```
+
+Cookie 优先级：
+
+```text
+WebSocket 临时 Cookie > 直播间 Cookie(cookie.rooms) > 默认 Cookie(cookie.douyin) > 自动获取
+```
+
+WebSocket 临时 Cookie 仅建议临时调试使用：
+
+```text
+ws://127.0.0.1:1088/ws/直播间ID?cookie_b64=BASE64URL_COOKIE
+```
+
+也支持直接传 URL 编码后的 Cookie：
+
+```text
+ws://127.0.0.1:1088/ws/直播间ID?cookie=URL_ENCODED_COOKIE
 ```
 
 ### 什么时候需要 Cookie

--- a/cmd/main/app.go
+++ b/cmd/main/app.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -26,7 +28,7 @@ type App struct {
 // NewApp 创建并返回一个新的 App 实例
 func NewApp(ctx context.Context, config *Config, logger *log.Logger) (*App, error) {
 
-	roomManager := NewRoomManager(logger, config.Unknown, config.Cookie.Douyin, config.Monitor.PollInterval, config.Monitor.NotifyInterval)
+	roomManager := NewRoomManager(logger, config.Unknown, config.Cookie.Douyin, config.Cookie.Rooms, config.Monitor.PollInterval, config.Monitor.NotifyInterval)
 	return &App{
 		ctx:         ctx,
 		logger:      logger,
@@ -77,15 +79,21 @@ func (a *App) Shutdown() error {
 
 // handleWebSocket 处理新的 WebSocket 连接请求
 func (a *App) handleWebSocket(w http.ResponseWriter, r *http.Request) {
-	roomID := strings.TrimPrefix(r.URL.Path, "/ws/")
+	roomID := strings.Trim(strings.TrimPrefix(r.URL.Path, "/ws/"), "/")
 	if roomID == "" {
 		http.Error(w, "无效的房间ID", http.StatusBadRequest)
 		return
 	}
 
+	cookieOverride, err := parseCookieOverride(r)
+	if err != nil {
+		http.Error(w, "Cookie 参数无效", http.StatusBadRequest)
+		return
+	}
+
 	a.logger.Printf("接收到 WebSocket 连接请求, 房间ID: %s, 客户端: %s", roomID, r.RemoteAddr)
 
-	room := a.roomManager.GetOrCreateRoom(roomID)
+	room := a.roomManager.GetOrCreateRoom(roomID, cookieOverride)
 	handler := NewWsHandler(room)
 
 	upgrader := gws.NewUpgrader(handler, &gws.ServerOption{
@@ -101,4 +109,37 @@ func (a *App) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	go socket.ReadLoop()
+}
+
+func parseCookieOverride(r *http.Request) (string, error) {
+	q := r.URL.Query()
+	if cookie := strings.TrimSpace(q.Get("cookie")); cookie != "" {
+		return cookie, nil
+	}
+
+	cookieB64 := strings.TrimSpace(q.Get("cookie_b64"))
+	if cookieB64 == "" {
+		return "", nil
+	}
+
+	cookie, err := decodeCookieBase64(cookieB64)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(cookie), nil
+}
+
+func decodeCookieBase64(value string) (string, error) {
+	decoders := []*base64.Encoding{
+		base64.RawURLEncoding,
+		base64.URLEncoding,
+		base64.StdEncoding,
+	}
+	for _, decoder := range decoders {
+		data, err := decoder.DecodeString(value)
+		if err == nil {
+			return string(data), nil
+		}
+	}
+	return "", fmt.Errorf("invalid base64 cookie")
 }

--- a/cmd/main/config.go
+++ b/cmd/main/config.go
@@ -14,7 +14,8 @@ import (
 
 // CookieConfig 存储 Cookie 配置
 type CookieConfig struct {
-	Douyin string // 抖音 Cookie
+	Douyin string            // 抖音默认 Cookie
+	Rooms  map[string]string // 按直播间 ID 配置的 Cookie
 }
 
 // MonitorConfig 存储未开播监控相关配置
@@ -81,6 +82,7 @@ func NewConfig() (*Config, error) {
 	viper.SetDefault("port", "1088")
 	viper.SetDefault("unknown", false)
 	viper.SetDefault("cookie.douyin", "")
+	viper.SetDefault("cookie.rooms", map[string]string{})
 	viper.SetDefault("monitor.poll_interval", "15s")
 	viper.SetDefault("monitor.notify_interval", "30s")
 	// 读取配置
@@ -118,6 +120,7 @@ func NewConfig() (*Config, error) {
 		Unknown: viper.GetBool("unknown"),
 		Cookie: CookieConfig{
 			Douyin: viper.GetString("cookie.douyin"),
+			Rooms:  viper.GetStringMapString("cookie.rooms"),
 		},
 		Monitor: MonitorConfig{
 			PollInterval:   pollInterval,

--- a/cmd/main/cookie_config_test.go
+++ b/cmd/main/cookie_config_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRoomManagerCookieForRoomPriority(t *testing.T) {
+	rm := NewRoomManager(nil, false, "global-cookie", map[string]string{
+		"1001": "room-cookie",
+	}, 0, 0)
+
+	if got := rm.cookieForRoom("1001", "override-cookie"); got != "override-cookie" {
+		t.Fatalf("override cookie should win, got %q", got)
+	}
+	if got := rm.cookieForRoom("1001", ""); got != "room-cookie" {
+		t.Fatalf("room cookie should win over global cookie, got %q", got)
+	}
+	if got := rm.cookieForRoom("1002", ""); got != "global-cookie" {
+		t.Fatalf("missing room cookie should fallback to global cookie, got %q", got)
+	}
+}
+
+func TestParseCookieOverride(t *testing.T) {
+	cookie := "ttwid=abc; sessionid=xyz"
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(cookie))
+
+	req := httptest.NewRequest("GET", "/ws/1001?cookie_b64="+encoded, nil)
+	got, err := parseCookieOverride(req)
+	if err != nil {
+		t.Fatalf("parse cookie_b64 failed: %v", err)
+	}
+	if got != cookie {
+		t.Fatalf("unexpected cookie: got %q want %q", got, cookie)
+	}
+
+	req = httptest.NewRequest("GET", "/ws/1001?cookie=ttwid%3Dabc%3B+sessionid%3Dxyz", nil)
+	got, err = parseCookieOverride(req)
+	if err != nil {
+		t.Fatalf("parse cookie failed: %v", err)
+	}
+	if got != cookie {
+		t.Fatalf("unexpected cookie: got %q want %q", got, cookie)
+	}
+}
+
+func TestRoomManagerKeySeparatesCookie(t *testing.T) {
+	keyA := roomManagerKey("1001", "cookie-a")
+	keyB := roomManagerKey("1001", "cookie-b")
+	if keyA == keyB {
+		t.Fatalf("different cookies should produce different room keys")
+	}
+	if got := roomManagerKey("1001", ""); got != "1001" {
+		t.Fatalf("empty cookie should keep legacy room key, got %q", got)
+	}
+}

--- a/cmd/main/room.go
+++ b/cmd/main/room.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,28 +36,57 @@ type RoomManager struct {
 	roomsMu        sync.RWMutex
 	logger         *log.Logger
 	unknown        bool
-	cookie         string // 抖音 Cookie
+	cookie         string            // 抖音默认 Cookie
+	roomCookies    map[string]string // 按直播间 ID 配置的 Cookie
 	pollInterval   time.Duration
 	notifyInterval time.Duration
 }
 
 // NewRoomManager 创建一个新的 RoomManager
-// cookie 参数：可选的抖音 Cookie
-func NewRoomManager(logger *log.Logger, unknown bool, cookie string, pollInterval time.Duration, notifyInterval time.Duration) *RoomManager {
+// cookie 参数：可选的抖音默认 Cookie
+func NewRoomManager(logger *log.Logger, unknown bool, cookie string, roomCookies map[string]string, pollInterval time.Duration, notifyInterval time.Duration) *RoomManager {
 	return &RoomManager{
 		rooms:          make(map[string]*Room),
 		logger:         logger,
 		unknown:        unknown,
 		cookie:         cookie,
+		roomCookies:    roomCookies,
 		pollInterval:   pollInterval,
 		notifyInterval: notifyInterval,
 	}
 }
 
+func (rm *RoomManager) cookieForRoom(roomID string, override string) string {
+	if cookie := strings.TrimSpace(override); cookie != "" {
+		return cookie
+	}
+
+	if rm.roomCookies != nil {
+		if cookie := strings.TrimSpace(rm.roomCookies[roomID]); cookie != "" {
+			return cookie
+		}
+	}
+
+	return strings.TrimSpace(rm.cookie)
+}
+
+func roomManagerKey(roomID string, cookie string) string {
+	cookie = strings.TrimSpace(cookie)
+	if cookie == "" {
+		return roomID
+	}
+
+	sum := sha256.Sum256([]byte(cookie))
+	return roomID + "#" + hex.EncodeToString(sum[:8])
+}
+
 // GetOrCreateRoom 获取或创建一个新的房间实例
-func (rm *RoomManager) GetOrCreateRoom(roomID string) *Room {
+func (rm *RoomManager) GetOrCreateRoom(roomID string, cookieOverride string) *Room {
+	cookie := rm.cookieForRoom(roomID, cookieOverride)
+	key := roomManagerKey(roomID, cookie)
+
 	rm.roomsMu.RLock()
-	room, ok := rm.rooms[roomID]
+	room, ok := rm.rooms[key]
 	rm.roomsMu.RUnlock()
 	if ok {
 		return room
@@ -62,17 +94,17 @@ func (rm *RoomManager) GetOrCreateRoom(roomID string) *Room {
 
 	rm.roomsMu.Lock()
 	defer rm.roomsMu.Unlock()
-	if room, ok = rm.rooms[roomID]; ok {
+	if room, ok = rm.rooms[key]; ok {
 		return room
 	}
 
-	room = NewRoom(roomID, rm.logger, rm.unknown, rm.cookie, rm.pollInterval, rm.notifyInterval, func() {
+	room = NewRoom(roomID, rm.logger, rm.unknown, cookie, rm.pollInterval, rm.notifyInterval, func() {
 		rm.roomsMu.Lock()
-		delete(rm.rooms, roomID)
+		delete(rm.rooms, key)
 		rm.roomsMu.Unlock()
 		rm.logger.Printf("房间 %s 已从管理器中移除", roomID)
 	})
-	rm.rooms[roomID] = room
+	rm.rooms[key] = room
 	return room
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,10 @@ monitor:
 
 # Cookie 配置（可选，不配置则自动获取）
 cookie:
-  # 抖音 Cookie（可选，用于需要登录态的请求）
+  # 抖音默认 Cookie（可选，用于需要登录态的请求）
   # 获取方式：浏览器打开 https://live.douyin.com -> F12 -> Network -> 复制任意请求的 Cookie
   douyin: ""
+  # 按直播间 ID 配置 Cookie（可选）
+  # 优先级：直播间 Cookie > 默认 Cookie > 自动获取
+  rooms:
+    # "123456789": "ttwid=...; sessionid=..."


### PR DESCRIPTION
## Summary
- add `cookie.rooms` for room-specific Douyin cookies
- keep old `cookie.douyin` config compatible as the global fallback
- support temporary WebSocket cookie override via `cookie_b64` or `cookie` query parameters
- separate internal room instances by cookie hash to avoid cross-account reuse
- document priority and add tests

Cookie priority:
`WebSocket temporary cookie > room cookie(cookie.rooms) > global cookie(cookie.douyin) > auto fetch`

Fixes #41.

## Test
- `go test ./cmd/main`
- `go test ./...`